### PR TITLE
Support entirely disabling claim expiration checks

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/FindUnusedClaimsTask.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/FindUnusedClaimsTask.java
@@ -48,10 +48,7 @@ class FindUnusedClaimsTask implements Runnable
         if (claimOwnerUUIDs.isEmpty()) return;
 
         // Don't do anything if claim expiration checking is disabled
-        if (!GriefPrevention.instance.config_claims_expirationEnabled) 
-        {
-            return;
-        }
+        if (!GriefPrevention.instance.config_claims_expirationEnabled) return;
 
         //wrap search around to beginning
         if (!claimOwnerIterator.hasNext())

--- a/src/main/java/me/ryanhamshire/GriefPrevention/FindUnusedClaimsTask.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/FindUnusedClaimsTask.java
@@ -47,6 +47,11 @@ class FindUnusedClaimsTask implements Runnable
         //don't do anything when there are no claims
         if (claimOwnerUUIDs.isEmpty()) return;
 
+        // Don't do anything if claim expiration checking is disabled
+        if (!GriefPrevention.instance.config_claims_expirationEnabled) {
+            return;
+        }
+
         //wrap search around to beginning
         if (!claimOwnerIterator.hasNext())
         {

--- a/src/main/java/me/ryanhamshire/GriefPrevention/FindUnusedClaimsTask.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/FindUnusedClaimsTask.java
@@ -48,7 +48,8 @@ class FindUnusedClaimsTask implements Runnable
         if (claimOwnerUUIDs.isEmpty()) return;
 
         // Don't do anything if claim expiration checking is disabled
-        if (!GriefPrevention.instance.config_claims_expirationEnabled) {
+        if (!GriefPrevention.instance.config_claims_expirationEnabled) 
+        {
             return;
         }
 

--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -117,7 +117,7 @@ public class GriefPrevention extends JavaPlugin
     public int config_claims_accruedIdleThreshold;                    //how far (in blocks) a player must move in order to not be considered afk/idle when determining accrued claim blocks
     public int config_claims_accruedIdlePercent;                    //how much percentage of claim block accruals should idle players get
     public int config_claims_maxDepth;                                //limit on how deep claims can go
-    public int config_claims_expirationEnabled;                     //whether automatic claim expiration is enabled (default true)
+    public boolean config_claims_expirationEnabled;                 //whether automatic claim expiration is enabled (default true)
     public int config_claims_expirationDays;                        //how many days of inactivity before a player loses his claims
     public int config_claims_expirationExemptionTotalBlocks;        //total claim blocks amount which will exempt a player from claim expiration
     public int config_claims_expirationExemptionBonusBlocks;        //bonus claim blocks amount which will exempt a player from claim expiration

--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -117,6 +117,7 @@ public class GriefPrevention extends JavaPlugin
     public int config_claims_accruedIdleThreshold;                    //how far (in blocks) a player must move in order to not be considered afk/idle when determining accrued claim blocks
     public int config_claims_accruedIdlePercent;                    //how much percentage of claim block accruals should idle players get
     public int config_claims_maxDepth;                                //limit on how deep claims can go
+    public int config_claims_expirationEnabled;                     //whether automatic claim expiration is enabled (default true)
     public int config_claims_expirationDays;                        //how many days of inactivity before a player loses his claims
     public int config_claims_expirationExemptionTotalBlocks;        //total claim blocks amount which will exempt a player from claim expiration
     public int config_claims_expirationExemptionBonusBlocks;        //bonus claim blocks amount which will exempt a player from claim expiration
@@ -554,6 +555,7 @@ public class GriefPrevention extends JavaPlugin
         this.config_claims_maxDepth = config.getInt("GriefPrevention.Claims.MaximumDepth", Integer.MIN_VALUE);
         this.config_claims_chestClaimExpirationDays = config.getInt("GriefPrevention.Claims.Expiration.ChestClaimDays", 7);
         this.config_claims_unusedClaimExpirationDays = config.getInt("GriefPrevention.Claims.Expiration.UnusedClaimDays", 14);
+        this.config_claims_expirationEnabled = config.getBoolean("GriefPrevention.Claims.Expiration.Enabled", true);
         this.config_claims_expirationDays = config.getInt("GriefPrevention.Claims.Expiration.AllClaims.DaysInactive", 60);
         this.config_claims_expirationExemptionTotalBlocks = config.getInt("GriefPrevention.Claims.Expiration.AllClaims.ExceptWhenOwnerHasTotalClaimBlocks", 10000);
         this.config_claims_expirationExemptionBonusBlocks = config.getInt("GriefPrevention.Claims.Expiration.AllClaims.ExceptWhenOwnerHasBonusClaimBlocks", 5000);


### PR DESCRIPTION
Make it possible to disable expiration checks entirely, by setting
`GriefPrevention.Claims.Expiration.Enabled` to false.

Nicer to be able to turn it off totally rather than just setting the
days inactive settings to a very high value, and saves inspecting each
player to see if they meet the criteria too.